### PR TITLE
 Style react-dates with omrs colors 

### DIFF
--- a/src/referrals-queue/react-dates-overrides.css
+++ b/src/referrals-queue/react-dates-overrides.css
@@ -24,6 +24,11 @@
   border: 1px solid var(--omrs-color-interaction-plus-one);
 }
 
+/* Will edit the underline in the focused input box */
+.DateInput_input__focused {
+  border-bottom: 2px solid var(--omrs-color-interaction);
+}
+
 /* Will edit when the second date (end date) in a range of dates */
 /* is not yet selected. Edits the dates between your mouse and said date */
 /* .CalendarDay__hovered_span:hover,

--- a/src/referrals-queue/react-dates-overrides.css
+++ b/src/referrals-queue/react-dates-overrides.css
@@ -1,0 +1,32 @@
+/* NOTE: the order of these styles DO matter */
+
+/* Will edit everything selected including everything between a range of dates */
+.CalendarDay__selected_span {
+  background: var(--omrs-color-interaction-minus-one);
+  border: 1px solid var(--omrs-color-interaction);
+}
+
+/* Will edit selected date or the endpoints of a range of dates */
+.CalendarDay__selected {
+  background: var(--omrs-color-interaction-plus-one);
+  border: 1px solid var(--omrs-color-interaction-plus-two);
+}
+
+/* Will edit when hovered over. _span style also has this property */
+.CalendarDay__selected:hover {
+  background: var(--omrs-color-interaction-plus-two);
+  border: 1px solid var(--omrs-color-interaction);
+}
+
+/* Will edit when hovered over. _span style also has this property */
+.CalendarDay__selected_span:hover {
+  background: var(--omrs-color-interaction);
+  border: 1px solid var(--omrs-color-interaction-plus-one);
+}
+
+/* Will edit when the second date (end date) in a range of dates */
+/* is not yet selected. Edits the dates between your mouse and said date */
+/* .CalendarDay__hovered_span:hover,
+.CalendarDay__hovered_span {
+  background: var(--omrs-color-interaction-minus-two);
+} */

--- a/src/referrals-queue/react-dates-overrides.css
+++ b/src/referrals-queue/react-dates-overrides.css
@@ -1,3 +1,5 @@
+/* This is based on https://github.com/airbnb/react-dates#overriding-styles */
+
 /* NOTE: the order of these styles DO matter */
 
 /* Will edit everything selected including everything between a range of dates */

--- a/src/referrals-queue/referrals-queue.component.tsx
+++ b/src/referrals-queue/referrals-queue.component.tsx
@@ -12,6 +12,7 @@ import { getReferrals } from "./referrals-queue.resource";
 // Override the webpack CSS loader config in order to load react-dates styles.
 //   See thread: https://github.com/webpack-contrib/css-loader/issues/295
 import "!style-loader!css-loader!react-dates/lib/css/_datepicker.css";
+import "!style-loader!css-loader!./react-dates-overrides.css";
 
 export default function ReferralsQueue(props: ReferralsQueueProps) {
   const [referrals, setReferrals]: [Referral[], Function] = React.useState([]);


### PR DESCRIPTION
Styled using the OMRS Styleguide [colors](https://styleguide.openmrs.org/?path=/story/openmrs-styleguide--colors). If we need it to be a different color palate, I think we should do that in a styleguide override (separately).

![screenshot--2020-04-13--171346](https://user-images.githubusercontent.com/1031876/79172769-763f6580-7daa-11ea-9cbb-ad1d03187a3c.png)
