### PR TITLE
Add returnUrl parameter

### DIFF
--- a/src/root.component.tsx
+++ b/src/root.component.tsx
@@ -45,7 +45,7 @@ defineConfigSchema("@pih/esm-referrals-queue", {
       },
       url: {
         default:
-          "/htmlformentryui/htmlform/editHtmlFormWithStandardUi.page?patientId=${patientUuid}&visitId=${visitUuid}&encounterId=${encounterUuid}&definitionUiResource=file:configuration/pih/htmlforms/section-mch-referral.xml",
+          "/htmlformentryui/htmlform/editHtmlFormWithStandardUi.page?patientId=${patientUuid}&visitId=${visitUuid}&encounterId=${encounterUuid}&definitionUiResource=file:configuration/pih/htmlforms/section-mch-referral.xml&returnUrl=/mirebalais/spa/referrals-queue",
         validators: [validators.isString, validateUrlTemplate]
       }
     }


### PR DESCRIPTION
Fixes the issue where the visit note form redirects back to the old visit note.